### PR TITLE
fix(Index.vue): Return hex value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ yarn add @caohenghu/vue-colorpicker
 
 | Name        | Type     | Args   | Description            |
 | ----------- | -------- | ------ | ---------------------- |
-| changeColor | Function | color  | `{ rgba: {}, hsv: {}}` |
+| changeColor | Function | color  | `{ rgba: {}, hsv: {}, hex: String}` |
 | openSucker  | Function | isOpen | `true` or `false`      |
 
 > if you want use sucker, then `openSucker`, `sucker-hide`, `sucker-canvas`, `sucker-area` is necessary. when you click sucker button, you can click it again or press key of `esc` to exit.

--- a/src/color/Index.vue
+++ b/src/color/Index.vue
@@ -175,7 +175,8 @@ export default {
         rgba() {
             this.$emit('changeColor', {
                 rgba: this.rgba,
-                hsv: this.hsv
+                hsv: this.hsv,
+                hex: this.modelHex
             })
         }
     },


### PR DESCRIPTION
We are using this library for our color picker but the problem is that I don't have any way to get the hex value internally from the `changeColor` function. This PR fixes this.

<img width="349" alt="image" src="https://user-images.githubusercontent.com/17470909/72489400-e7748880-384e-11ea-9022-45ab950dec32.png">

Hoping that this PR would be merged.