### PR TITLE
Hidding of Color History

### DIFF
--- a/src/color/Index.vue
+++ b/src/color/Index.vue
@@ -56,6 +56,7 @@
             @inputColor="inputRgba"
         />
         <Colors
+            v-if="colorHistoryHide"
             :color="rgbaString"
             :colors-default="colorsDefault"
             :colors-history-key="colorsHistoryKey"
@@ -94,6 +95,10 @@ export default {
             default: 'dark'
         },
         suckerHide: {
+            type: Boolean,
+            default: true
+        },
+        colorHistoryHide: {
             type: Boolean,
             default: true
         },


### PR DESCRIPTION
Added a simple `:color-history-hide="false"` prop that hides the color history row if not needed. Added in much the same way as `:sucker-hide="false"`. Default is true so the row is shown.